### PR TITLE
feat: implement organization apis of logging

### DIFF
--- a/google-cloud-logging/clirr-ignored-differences.xml
+++ b/google-cloud-logging/clirr-ignored-differences.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://mojo.codehaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+    <difference>
+        <className>com/google/cloud/logging/Logging</className>
+        <method>com.google.cloud.logging.CmekSettings getCmekSettings(java.lang.String)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+    <difference>
+        <className>com/google/cloud/logging/Logging</className>
+        <method>com.google.api.core.ApiFuture getCmekSettingsAsync(java.lang.String)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+    <difference>
+        <className>com/google/cloud/logging/Logging</className>
+        <method>com.google.cloud.logging.CmekSettings updateCmekSettings(com.google.cloud.logging.CmekSettings)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+    <difference>
+        <className>com/google/cloud/logging/Logging</className>
+        <method>com.google.api.core.ApiFuture updateCmekSettingsAsync(com.google.cloud.logging.CmekSettings)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+    <difference>
+        <className>com/google/cloud/logging/spi/v2/LoggingRpc</className>
+        <method> com.google.api.core.ApiFuture getCmekSettings(com.google.logging.v2.GetCmekSettingsRequest)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+    <difference>
+        <className>com/google/cloud/logging/spi/v2/LoggingRpc</className>
+        <method>com.google.api.core.ApiFuture updateCmekSettings(com.google.logging.v2.UpdateCmekSettingsRequest)</method>
+        <differenceType>7012</differenceType>
+    </difference>
+</differences>

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.logging;
+
+import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+
+/**
+ * CmekSettings Describes the customer-managed encryption key (CMEK) settings associated with a
+ * project, folder, organization, billing account, or flexible resource.
+ *
+ * <p>Note: CMEK for the Logs Router can currently only be configured for GCP organizations. Once
+ * configured, it applies to all projects and folders in the GCP organization.
+ *
+ * @see <a href="https://cloud.google.com/logging/docs/routing/managed-encryption">Enabling CMEK for
+ *     Logs Router</a> for more information.
+ */
+public class CmekSettings {
+
+  static final Function<com.google.logging.v2.CmekSettings, CmekSettings> FROM_PB_FUNCTION =
+      new Function<com.google.logging.v2.CmekSettings, CmekSettings>() {
+        @Override
+        public CmekSettings apply(com.google.logging.v2.CmekSettings cmekSettingsPb) {
+          return cmekSettingsPb != null ? CmekSettings.fromPb(cmekSettingsPb) : null;
+        }
+      };
+
+  static final Function<CmekSettings, com.google.logging.v2.CmekSettings> TO_PB_FUNCTION =
+      new Function<CmekSettings, com.google.logging.v2.CmekSettings>() {
+        @Override
+        public com.google.logging.v2.CmekSettings apply(CmekSettings cmekSettings) {
+          return cmekSettings != null ? cmekSettings.toPb() : null;
+        }
+      };
+
+  private String name;
+  private String kmsKeyName;
+  private String serviceAccountId;
+
+  /** A builder for {@code CmekSettings} objects. */
+  static class Builder {
+    private String name;
+    private String kmsKeyName;
+    private String serviceAccountId;
+
+    Builder() {}
+
+    Builder(CmekSettings settings) {
+      this.name = settings.name;
+      this.kmsKeyName = settings.kmsKeyName;
+      this.serviceAccountId = settings.serviceAccountId;
+    }
+
+    Builder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    Builder setKmsKeyName(String kmsKeyName) {
+      this.kmsKeyName = kmsKeyName;
+      return this;
+    }
+
+    Builder setServiceAccountId(String serviceAccountId) {
+      this.serviceAccountId = serviceAccountId;
+      return this;
+    }
+
+    /** Creates a {@code CmekSettings} object. */
+    CmekSettings build() {
+      return new CmekSettings(this);
+    }
+  }
+
+  CmekSettings(Builder builder) {
+    this.name = builder.name;
+    this.kmsKeyName = builder.kmsKeyName;
+    this.serviceAccountId = builder.serviceAccountId;
+  }
+
+  /** Returns the name of the CMEK settings. */
+  public String getName() {
+    return name;
+  }
+
+  /** Returns the KMS key name. */
+  public String getKmsKeyName() {
+    return kmsKeyName;
+  }
+
+  /** Returns the service account. */
+  public String getServiceAccountId() {
+    return serviceAccountId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("kmsKeyName", kmsKeyName)
+        .add("serviceAccountId", serviceAccountId)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CmekSettings settings = (CmekSettings) o;
+    return Objects.equals(name, settings.name)
+        && Objects.equals(kmsKeyName, settings.kmsKeyName)
+        && Objects.equals(serviceAccountId, settings.serviceAccountId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, kmsKeyName, serviceAccountId);
+  }
+
+  /** Returns a builder for the {@link CmekSettings} object. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /** Returns a builder for the {@link CmekSettings} object. */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  com.google.logging.v2.CmekSettings toPb() {
+    return com.google.logging.v2.CmekSettings.newBuilder()
+        .setName(name)
+        .setKmsKeyName(kmsKeyName)
+        .setServiceAccountId(serviceAccountId)
+        .build();
+  }
+
+  static CmekSettings fromPb(com.google.logging.v2.CmekSettings settingsPb) {
+    CmekSettings.Builder builder = newBuilder();
+    builder.setName(settingsPb.getName());
+    builder.setKmsKeyName(settingsPb.getKmsKeyName());
+    builder.setServiceAccountId(settingsPb.getServiceAccountId());
+    return builder.build();
+  }
+}

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
@@ -20,10 +20,10 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 /**
- * CmekSettings Describes the customer-managed encryption key (CMEK) settings associated with a
- * project, folder, organization, billing account, or flexible resource.
+ * Describes the customer-managed encryption key (CMEK) settings associated with a project, folder,
+ * organization, billing account, or flexible resource.
  *
- * <p>Note: CMEK for the Logs Router can currently only be configured for GCP organizations. Once
+ * <p>Note: CMEK for the Logs Router currently can be configured only for GCP organizations. Once
  * configured, it applies to all projects and folders in the GCP organization.
  *
  * @see <a href="https://cloud.google.com/logging/docs/routing/managed-encryption">Enabling CMEK for
@@ -52,7 +52,7 @@ public class CmekSettings {
   private String serviceAccountId;
 
   /** A builder for {@code CmekSettings} objects. */
-  static class Builder {
+  public static class Builder {
     private String name;
     private String kmsKeyName;
     private String serviceAccountId;
@@ -65,23 +65,23 @@ public class CmekSettings {
       this.serviceAccountId = settings.serviceAccountId;
     }
 
-    Builder setName(String name) {
+    public Builder setName(String name) {
       this.name = name;
       return this;
     }
 
-    Builder setKmsKeyName(String kmsKeyName) {
+    public Builder setKmsKeyName(String kmsKeyName) {
       this.kmsKeyName = kmsKeyName;
       return this;
     }
 
-    Builder setServiceAccountId(String serviceAccountId) {
+    public Builder setServiceAccountId(String serviceAccountId) {
       this.serviceAccountId = serviceAccountId;
       return this;
     }
 
     /** Creates a {@code CmekSettings} object. */
-    CmekSettings build() {
+    public CmekSettings build() {
       return new CmekSettings(this);
     }
   }

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/CmekSettings.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 /**
  * Describes the customer-managed encryption key (CMEK) settings associated with a project, folder,
- * organization, billing account, or flexible resource.
+ * organization, billing account or flexible resource.
  *
  * <p>Note: CMEK for the Logs Router currently can be configured only for GCP organizations. Once
  * configured, it applies to all projects and folders in the GCP organization.
@@ -57,9 +57,9 @@ public class CmekSettings {
     private String kmsKeyName;
     private String serviceAccountId;
 
-    Builder() {}
+    private Builder() {}
 
-    Builder(CmekSettings settings) {
+    private Builder(CmekSettings settings) {
       this.name = settings.name;
       this.kmsKeyName = settings.kmsKeyName;
       this.serviceAccountId = settings.serviceAccountId;

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -669,6 +669,89 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   ApiFuture<Boolean> deleteMetricAsync(String metric);
 
   /**
+   * Returns the requested CMEK settings or {@code null} if not found.
+   *
+   * <p>Example of getting a CMEK settings.
+   *
+   * <pre>{@code
+   * String cmekSettingsName = "my_cmek_settings_name";
+   * CmekSettings settings = logging.getCmekSettings(cmekSettingsName);
+   * if (settings == null) {
+   *   // CMEK settings was not found
+   * }
+   * }</pre>
+   *
+   * @throws LoggingException upon failure
+   */
+  CmekSettings getCmekSettings(String cmekSettings);
+
+  /**
+   * Sends a request for getting a CMEK settings. This method returns a {@code ApiFuture} object to
+   * consume the result. {@link ApiFuture#get()} returns the requested CMEK settings or {@code null}
+   * if not found.
+   *
+   * <p>Example of asynchronously getting a CMEK settings.
+   *
+   * <pre>{@code
+   * String cmekSettingsName = "my_cmek_settings_name";
+   * ApiFuture<CmekSettings> future = logging.getCmekSettingsAsync(cmekSettingsName);
+   * // ...
+   * CmekSettings settings = future.get();
+   * if (settings == null) {
+   *   // CMEK settings was not found
+   * }
+   * }</pre>
+   *
+   * @throws LoggingException upon failure
+   */
+  ApiFuture<CmekSettings> getCmekSettingsAsync(String cmekSettings);
+
+  /**
+   * Updates a CMEK settings or creates one if it does not exist.
+   *
+   * <p>Example of updating a CMEK settings.
+   *
+   * <pre>{@code
+   * String cmekSettingsName = "my_cmek_settings_name";
+   * String kmsKeyName = "my_kms_key";
+   * String serviceAccount = "my_service_account";
+   * CmekSettings settings = CmekSettings.newBuilder()
+   *     .setName(cmekSettingsName)
+   *     .setKmsKeyName(kmsKeyName)
+   *     .setServiceAccountId(serviceAccount)
+   *     .build();
+   * CmekSettings cmkSettings = logging.updateCmekSettings(settings);
+   * }</pre>
+   *
+   * @return the updated CMEK settings
+   * @throws LoggingException upon failure
+   */
+  CmekSettings updateCmekSettings(CmekSettings cmekSettings);
+
+  /**
+   * Sends a request for updating a CMEK settings (or creating it, if it does not exist). This
+   * method returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()}
+   * returns the updated/created CMEK settings or {@code null} if not found.
+   *
+   * <p>Example of asynchronously updating a CMEK settings.
+   *
+   * <pre>{@code
+   * String cmekSettingsName = "my_cmek_settings_name";
+   * String kmsKeyName = "my_kms_key";
+   * String serviceAccount = "my_service_account";
+   * CmekSettings settings = CmekSettings.newBuilder()
+   *     .setName(cmekSettingsName)
+   *     .setKmsKeyName(kmsKeyName)
+   *     .setServiceAccountId(serviceAccount)
+   *     .build();
+   * ApiFuture<CmekSettings> future = logging.updateCmekSettingsAsync(settings);
+   * // ...
+   * CmekSettings cmkSettings = future.get();
+   * }</pre>
+   */
+  ApiFuture<CmekSettings> updateCmekSettingsAsync(CmekSettings cmekSettings);
+
+  /**
    * Flushes any pending asynchronous logging writes. Logs are automatically flushed based on time
    * and message count that be configured via {@link com.google.api.gax.batching.BatchingSettings},
    * Logs are also flushed if enabled, at or above flush severity, see {@link #setFlushSeverity}.

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/Logging.java
@@ -671,13 +671,13 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   /**
    * Returns the requested CMEK settings or {@code null} if not found.
    *
-   * <p>Example of getting a CMEK settings.
+   * <p>Example of getting the CMEK settings.
    *
    * <pre>{@code
    * String cmekSettingsName = "my_cmek_settings_name";
    * CmekSettings settings = logging.getCmekSettings(cmekSettingsName);
    * if (settings == null) {
-   *   // CMEK settings was not found
+   *   // CMEK settings were not found
    * }
    * }</pre>
    *
@@ -686,11 +686,11 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   CmekSettings getCmekSettings(String cmekSettings);
 
   /**
-   * Sends a request for getting a CMEK settings. This method returns a {@code ApiFuture} object to
+   * Sends a request to get the CMEK settings. This method returns a {@code ApiFuture} object to
    * consume the result. {@link ApiFuture#get()} returns the requested CMEK settings or {@code null}
    * if not found.
    *
-   * <p>Example of asynchronously getting a CMEK settings.
+   * <p>Example of asynchronously getting the CMEK settings.
    *
    * <pre>{@code
    * String cmekSettingsName = "my_cmek_settings_name";
@@ -698,7 +698,7 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
    * // ...
    * CmekSettings settings = future.get();
    * if (settings == null) {
-   *   // CMEK settings was not found
+   *   // CMEK settings were not found
    * }
    * }</pre>
    *
@@ -707,9 +707,9 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   ApiFuture<CmekSettings> getCmekSettingsAsync(String cmekSettings);
 
   /**
-   * Updates a CMEK settings or creates one if it does not exist.
+   * Updates the CMEK settings or creates one if it does not exist.
    *
-   * <p>Example of updating a CMEK settings.
+   * <p>Example of updating the CMEK settings.
    *
    * <pre>{@code
    * String cmekSettingsName = "my_cmek_settings_name";
@@ -729,11 +729,11 @@ public interface Logging extends AutoCloseable, Service<LoggingOptions> {
   CmekSettings updateCmekSettings(CmekSettings cmekSettings);
 
   /**
-   * Sends a request for updating a CMEK settings (or creating it, if it does not exist). This
+   * Sends a request for updating the CMEK settings (or creating it, if it does not exist). This
    * method returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()}
    * returns the updated/created CMEK settings or {@code null} if not found.
    *
-   * <p>Example of asynchronously updating a CMEK settings.
+   * <p>Example of asynchronously updating the CMEK settings.
    *
    * <pre>{@code
    * String cmekSettingsName = "my_cmek_settings_name";

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/LoggingImpl.java
@@ -51,6 +51,7 @@ import com.google.logging.v2.CreateSinkRequest;
 import com.google.logging.v2.DeleteLogMetricRequest;
 import com.google.logging.v2.DeleteLogRequest;
 import com.google.logging.v2.DeleteSinkRequest;
+import com.google.logging.v2.GetCmekSettingsRequest;
 import com.google.logging.v2.GetLogMetricRequest;
 import com.google.logging.v2.GetSinkRequest;
 import com.google.logging.v2.ListLogEntriesRequest;
@@ -65,6 +66,7 @@ import com.google.logging.v2.ProjectLogName;
 import com.google.logging.v2.ProjectMetricName;
 import com.google.logging.v2.ProjectName;
 import com.google.logging.v2.ProjectSinkName;
+import com.google.logging.v2.UpdateCmekSettingsRequest;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
@@ -523,6 +525,33 @@ class LoggingImpl extends BaseService<LoggingOptions> implements Logging {
             .setMetricName(ProjectMetricName.of(getOptions().getProjectId(), metric).toString())
             .build();
     return transform(rpc.delete(request), EMPTY_TO_BOOLEAN_FUNCTION);
+  }
+
+  @Override
+  public CmekSettings getCmekSettings(String cmekSettings) {
+    return get(getCmekSettingsAsync(cmekSettings));
+  }
+
+  @Override
+  public ApiFuture<CmekSettings> getCmekSettingsAsync(String cmekSettings) {
+    GetCmekSettingsRequest request =
+        GetCmekSettingsRequest.newBuilder().setName(cmekSettings).build();
+    return transform(rpc.getCmekSettings(request), CmekSettings.FROM_PB_FUNCTION);
+  }
+
+  @Override
+  public CmekSettings updateCmekSettings(CmekSettings cmekSettings) {
+    return get(updateCmekSettingsAsync(cmekSettings));
+  }
+
+  @Override
+  public ApiFuture<CmekSettings> updateCmekSettingsAsync(CmekSettings cmekSettings) {
+    UpdateCmekSettingsRequest request =
+        UpdateCmekSettingsRequest.newBuilder()
+            .setName(cmekSettings.getName())
+            .setCmekSettings(cmekSettings.toPb())
+            .build();
+    return transform(rpc.updateCmekSettings(request), CmekSettings.FROM_PB_FUNCTION);
   }
 
   private static WriteLogEntriesRequest writeLogEntriesRequest(

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/GrpcLoggingRpc.java
@@ -45,11 +45,13 @@ import com.google.cloud.logging.v2.LoggingSettings;
 import com.google.cloud.logging.v2.MetricsClient;
 import com.google.cloud.logging.v2.MetricsSettings;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.logging.v2.CmekSettings;
 import com.google.logging.v2.CreateLogMetricRequest;
 import com.google.logging.v2.CreateSinkRequest;
 import com.google.logging.v2.DeleteLogMetricRequest;
 import com.google.logging.v2.DeleteLogRequest;
 import com.google.logging.v2.DeleteSinkRequest;
+import com.google.logging.v2.GetCmekSettingsRequest;
 import com.google.logging.v2.GetLogMetricRequest;
 import com.google.logging.v2.GetSinkRequest;
 import com.google.logging.v2.ListLogEntriesRequest;
@@ -62,6 +64,7 @@ import com.google.logging.v2.ListSinksRequest;
 import com.google.logging.v2.ListSinksResponse;
 import com.google.logging.v2.LogMetric;
 import com.google.logging.v2.LogSink;
+import com.google.logging.v2.UpdateCmekSettingsRequest;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
@@ -219,6 +222,19 @@ public class GrpcLoggingRpc implements LoggingRpc {
   public ApiFuture<Empty> delete(DeleteSinkRequest request) {
     return translate(
         configClient.deleteSinkCallable().futureCall(request), true, StatusCode.Code.NOT_FOUND);
+  }
+
+  @Override
+  public ApiFuture<CmekSettings> getCmekSettings(GetCmekSettingsRequest request) {
+    return translate(
+        configClient.getCmekSettingsCallable().futureCall(request),
+        true,
+        StatusCode.Code.NOT_FOUND);
+  }
+
+  @Override
+  public ApiFuture<CmekSettings> updateCmekSettings(UpdateCmekSettingsRequest request) {
+    return translate(configClient.updateCmekSettingsCallable().futureCall(request), true);
   }
 
   @Override

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
@@ -171,7 +171,7 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
   ApiFuture<Empty> delete(DeleteLogMetricRequest request);
 
   /**
-   * Sends a request to get a CMEK settings. This method returns a {@code ApiFuture} object to
+   * Sends a request to get the CMEK settings. This method returns a {@code ApiFuture} object to
    * consume the result.{@link ApiFuture#get()} returns the requested CMEK settings or {@code null}
    * if the CMEK settings was not found.
    *
@@ -180,9 +180,9 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
   ApiFuture<CmekSettings> getCmekSettings(GetCmekSettingsRequest request);
 
   /**
-   * Sends a request to update a CMEK settings. If the CMEK settings does not exist, it is created.
-   * This method returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()}
-   * returns the updated or created CMEK settings.
+   * Sends a request to update the CMEK settings. If the CMEK settings does not exist, it is
+   * created. This method returns a {@code ApiFuture} object to consume the result. {@link
+   * ApiFuture#get()} returns the updated or created CMEK settings.
    *
    * @param request the request object containing all of the parameters for the API call
    */

--- a/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
+++ b/google-cloud-logging/src/main/java/com/google/cloud/logging/spi/v2/LoggingRpc.java
@@ -18,11 +18,13 @@ package com.google.cloud.logging.spi.v2;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.ServiceRpc;
+import com.google.logging.v2.CmekSettings;
 import com.google.logging.v2.CreateLogMetricRequest;
 import com.google.logging.v2.CreateSinkRequest;
 import com.google.logging.v2.DeleteLogMetricRequest;
 import com.google.logging.v2.DeleteLogRequest;
 import com.google.logging.v2.DeleteSinkRequest;
+import com.google.logging.v2.GetCmekSettingsRequest;
 import com.google.logging.v2.GetLogMetricRequest;
 import com.google.logging.v2.GetSinkRequest;
 import com.google.logging.v2.ListLogEntriesRequest;
@@ -35,6 +37,7 @@ import com.google.logging.v2.ListSinksRequest;
 import com.google.logging.v2.ListSinksResponse;
 import com.google.logging.v2.LogMetric;
 import com.google.logging.v2.LogSink;
+import com.google.logging.v2.UpdateCmekSettingsRequest;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
@@ -166,4 +169,22 @@ public interface LoggingRpc extends AutoCloseable, ServiceRpc {
    * @param request the request object containing all of the parameters for the API call
    */
   ApiFuture<Empty> delete(DeleteLogMetricRequest request);
+
+  /**
+   * Sends a request to get a CMEK settings. This method returns a {@code ApiFuture} object to
+   * consume the result.{@link ApiFuture#get()} returns the requested CMEK settings or {@code null}
+   * if the CMEK settings was not found.
+   *
+   * @param request
+   */
+  ApiFuture<CmekSettings> getCmekSettings(GetCmekSettingsRequest request);
+
+  /**
+   * Sends a request to update a CMEK settings. If the CMEK settings does not exist, it is created.
+   * This method returns a {@code ApiFuture} object to consume the result. {@link ApiFuture#get()}
+   * returns the updated or created CMEK settings.
+   *
+   * @param request the request object containing all of the parameters for the API call
+   */
+  ApiFuture<CmekSettings> updateCmekSettings(UpdateCmekSettingsRequest request);
 }

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/CmekSettingsTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/CmekSettingsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.logging;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CmekSettingsTest {
+
+  private static final String PROJECT = "project";
+  private static final String ORGANIZATIONS = "organization";
+  private static final String CMEK_SETTINGS_NAME =
+      "organizations/" + ORGANIZATIONS + "/cmekSettings/test";
+  private static final String KMS_KEY_NAME =
+      "projects/" + PROJECT + "/locations/my-region/keyRings/key-ring-name/cryptoKeys/key-name";
+  private static final String SERVICE_ACCOUNT = "service-account";
+  private static final CmekSettings CMEK_SETTINGS =
+      CmekSettings.newBuilder()
+          .setName(CMEK_SETTINGS_NAME)
+          .setKmsKeyName(KMS_KEY_NAME)
+          .setServiceAccountId(SERVICE_ACCOUNT)
+          .build();
+  private static final String NEW_CMEK_SETTINGS_NAME =
+      "organizations/" + ORGANIZATIONS + "/cmekSettings/test";
+  private static final String NEW_KMS_KEY_NAME =
+      "projects/" + PROJECT + "/locations/my-region/keyRings/key-ring-name/cryptoKeys/key-name";
+  private static final String NEW_SERVICE_ACCOUNT = "service-account";
+
+  @Test
+  public void testToBuilder() {
+    compareCmekSettings(CMEK_SETTINGS, CMEK_SETTINGS.toBuilder().build());
+    CmekSettings cmekSettings =
+        CMEK_SETTINGS
+            .toBuilder()
+            .setName(NEW_CMEK_SETTINGS_NAME)
+            .setKmsKeyName(NEW_KMS_KEY_NAME)
+            .setServiceAccountId(NEW_SERVICE_ACCOUNT)
+            .build();
+    assertEquals(NEW_CMEK_SETTINGS_NAME, cmekSettings.getName());
+    assertEquals(NEW_KMS_KEY_NAME, cmekSettings.getKmsKeyName());
+    assertEquals(NEW_SERVICE_ACCOUNT, cmekSettings.getServiceAccountId());
+    cmekSettings =
+        cmekSettings
+            .toBuilder()
+            .setName(CMEK_SETTINGS_NAME)
+            .setKmsKeyName(KMS_KEY_NAME)
+            .setServiceAccountId(SERVICE_ACCOUNT)
+            .build();
+    compareCmekSettings(CMEK_SETTINGS, cmekSettings);
+  }
+
+  @Test
+  public void testBuilder() {
+    assertEquals(CMEK_SETTINGS_NAME, CMEK_SETTINGS.getName());
+    assertEquals(KMS_KEY_NAME, CMEK_SETTINGS.getKmsKeyName());
+    assertEquals(SERVICE_ACCOUNT, CMEK_SETTINGS.getServiceAccountId());
+  }
+
+  @Test
+  public void testToAndFromPb() {
+    compareCmekSettings(CMEK_SETTINGS, CmekSettings.fromPb(CMEK_SETTINGS.toPb()));
+  }
+
+  private void compareCmekSettings(CmekSettings expected, CmekSettings actual) {
+    assertEquals(expected, actual);
+    assertEquals(expected.toString(), actual.toString());
+    assertEquals(expected.getName(), actual.getName());
+    assertEquals(expected.getKmsKeyName(), actual.getKmsKeyName());
+    assertEquals(expected.getServiceAccountId(), actual.getServiceAccountId());
+  }
+}

--- a/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
+++ b/google-cloud-logging/src/test/java/com/google/cloud/logging/LoggingImplTest.java
@@ -51,6 +51,7 @@ import com.google.logging.v2.CreateSinkRequest;
 import com.google.logging.v2.DeleteLogMetricRequest;
 import com.google.logging.v2.DeleteLogRequest;
 import com.google.logging.v2.DeleteSinkRequest;
+import com.google.logging.v2.GetCmekSettingsRequest;
 import com.google.logging.v2.GetLogMetricRequest;
 import com.google.logging.v2.GetSinkRequest;
 import com.google.logging.v2.ListLogEntriesRequest;
@@ -63,6 +64,7 @@ import com.google.logging.v2.ListSinksRequest;
 import com.google.logging.v2.ListSinksResponse;
 import com.google.logging.v2.LogMetric;
 import com.google.logging.v2.LogSink;
+import com.google.logging.v2.UpdateCmekSettingsRequest;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.logging.v2.UpdateSinkRequest;
 import com.google.logging.v2.WriteLogEntriesRequest;
@@ -93,6 +95,18 @@ public class LoggingImplTest {
   private static final String DESCRIPTION = "description";
   private static final MetricInfo METRIC_INFO =
       MetricInfo.newBuilder(METRIC_NAME, FILTER).setDescription(DESCRIPTION).build();
+  private static final String ORGANIZATIONS = "organization";
+  private static final String CMEK_SETTINGS_NAME =
+      "organizations/" + ORGANIZATIONS + "/cmekSettings/test";
+  private static final String KMS_KEY_NAME =
+      "projects/" + PROJECT + "/locations/my-region/keyRings/key-ring-name/cryptoKeys/key-name";
+  private static final String SERVICE_ACCOUNT = "service-account";
+  private static final CmekSettings CMEK_SETTINGS =
+      CmekSettings.newBuilder()
+          .setName(CMEK_SETTINGS_NAME)
+          .setKmsKeyName(KMS_KEY_NAME)
+          .setServiceAccountId(SERVICE_ACCOUNT)
+          .build();
   private static final com.google.api.MonitoredResourceDescriptor DESCRIPTOR_PB =
       com.google.api.MonitoredResourceDescriptor.getDefaultInstance();
   private static final MonitoredResourceDescriptor DESCRIPTOR =
@@ -886,6 +900,90 @@ public class LoggingImplTest {
         logging.listMetricsAsync(ListOption.pageSize(42), ListOption.pageToken(cursor)).get();
     assertEquals(cursor, page.getNextPageToken());
     assertArrayEquals(sinkList.toArray(), Iterables.toArray(page.getValues(), Metric.class));
+  }
+
+  @Test
+  public void testGetCmekSettings() {
+    GetCmekSettingsRequest request =
+        GetCmekSettingsRequest.newBuilder().setName(CMEK_SETTINGS_NAME).build();
+    EasyMock.expect(loggingRpcMock.getCmekSettings(request))
+        .andReturn(ApiFutures.immediateFuture(CMEK_SETTINGS.toPb()));
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    CmekSettings cmekSettings = logging.getCmekSettings(CMEK_SETTINGS_NAME);
+    assertEquals(CMEK_SETTINGS_NAME, cmekSettings.getName());
+    assertEquals(KMS_KEY_NAME, cmekSettings.getKmsKeyName());
+    assertEquals(SERVICE_ACCOUNT, cmekSettings.getServiceAccountId());
+  }
+
+  @Test
+  public void testGetCmekSettings_Null() {
+    GetCmekSettingsRequest request =
+        GetCmekSettingsRequest.newBuilder().setName(CMEK_SETTINGS_NAME).build();
+    ApiFuture<com.google.logging.v2.CmekSettings> response = ApiFutures.immediateFuture(null);
+    EasyMock.expect(loggingRpcMock.getCmekSettings(request)).andReturn(response);
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    assertNull(logging.getCmekSettings(CMEK_SETTINGS_NAME));
+  }
+
+  @Test
+  public void testGetCmekSettingsAsync() throws ExecutionException, InterruptedException {
+    GetCmekSettingsRequest request =
+        GetCmekSettingsRequest.newBuilder().setName(CMEK_SETTINGS_NAME).build();
+    EasyMock.expect(loggingRpcMock.getCmekSettings(request))
+        .andReturn(ApiFutures.immediateFuture(CMEK_SETTINGS.toPb()));
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    CmekSettings cmekSettings = logging.getCmekSettingsAsync(CMEK_SETTINGS_NAME).get();
+    assertEquals(CMEK_SETTINGS_NAME, cmekSettings.getName());
+    assertEquals(KMS_KEY_NAME, cmekSettings.getKmsKeyName());
+    assertEquals(SERVICE_ACCOUNT, cmekSettings.getServiceAccountId());
+  }
+
+  @Test
+  public void testGetCmekSettingsAsync_Null() throws ExecutionException, InterruptedException {
+    GetCmekSettingsRequest request =
+        GetCmekSettingsRequest.newBuilder().setName(CMEK_SETTINGS_NAME).build();
+    ApiFuture<com.google.logging.v2.CmekSettings> response = ApiFutures.immediateFuture(null);
+    EasyMock.expect(loggingRpcMock.getCmekSettings(request)).andReturn(response);
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    assertNull(logging.getCmekSettingsAsync(CMEK_SETTINGS_NAME).get());
+  }
+
+  @Test
+  public void testUpdateCmekSettings() {
+    UpdateCmekSettingsRequest request =
+        UpdateCmekSettingsRequest.newBuilder()
+            .setName(CMEK_SETTINGS_NAME)
+            .setCmekSettings(CMEK_SETTINGS.toPb())
+            .build();
+    EasyMock.expect(loggingRpcMock.updateCmekSettings(request))
+        .andReturn(ApiFutures.immediateFuture(CMEK_SETTINGS.toPb()));
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    CmekSettings cmekSettings = logging.updateCmekSettings(CMEK_SETTINGS);
+    assertEquals(CMEK_SETTINGS_NAME, cmekSettings.getName());
+    assertEquals(KMS_KEY_NAME, cmekSettings.getKmsKeyName());
+    assertEquals(SERVICE_ACCOUNT, cmekSettings.getServiceAccountId());
+  }
+
+  @Test
+  public void testUpdateCmekSettingsAsync() throws ExecutionException, InterruptedException {
+    UpdateCmekSettingsRequest request =
+        UpdateCmekSettingsRequest.newBuilder()
+            .setName(CMEK_SETTINGS_NAME)
+            .setCmekSettings(CMEK_SETTINGS.toPb())
+            .build();
+    EasyMock.expect(loggingRpcMock.updateCmekSettings(request))
+        .andReturn(ApiFutures.immediateFuture(CMEK_SETTINGS.toPb()));
+    EasyMock.replay(rpcFactoryMock, loggingRpcMock);
+    logging = options.getService();
+    CmekSettings cmekSettings = logging.updateCmekSettingsAsync(CMEK_SETTINGS).get();
+    assertEquals(CMEK_SETTINGS_NAME, cmekSettings.getName());
+    assertEquals(KMS_KEY_NAME, cmekSettings.getKmsKeyName());
+    assertEquals(SERVICE_ACCOUNT, cmekSettings.getServiceAccountId());
   }
 
   @Test


### PR DESCRIPTION
This PR implements the following [Organization ](https://cloud.google.com/logging/docs/reference/v2/rest/v2/organizations)APIs of logging.

-  [getcmeksettings](https://cloud.google.com/logging/docs/reference/v2/rest/v2/organizations#getcmeksettings) : Gets the Logs Router CMEK settings for the given resource.

- [updatecmeksettings](https://cloud.google.com/logging/docs/reference/v2/rest/v2/organizations#updatecmeksettings) : Updates the Logs Router CMEK settings for the given resource.